### PR TITLE
Encode each line before scanning

### DIFF
--- a/lib/storyboardlint.rb
+++ b/lib/storyboardlint.rb
@@ -166,6 +166,7 @@ module StoryboardLint
         source_files.each do |source_file|
           File.readlines(source_file, :encoding => 'UTF-8').each_with_index do |line, idx|
             # class names
+            line.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
             line.scan(@matcher.class_regex).each do |match|
               @class_names << {:file => source_file, :line => idx + 1, :class_name => match[0]}
             end


### PR DESCRIPTION
Fixes #10 (at least for me).

```
/usr/local/var/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/storyboardlint-0.2.2/lib/storyboardlint.rb:169:in `scan': invalid byte sequence in UTF-8 (ArgumentError)
```
